### PR TITLE
Deployment products

### DIFF
--- a/common/deployment.go
+++ b/common/deployment.go
@@ -60,6 +60,12 @@ type Deployment interface {
 	IsForce() bool
 
 	Status() DeploymentStatus
+	// Deploys can result in products, eg. the URL to the build log. Phases
+	// store their products here for use by other phases/the end user.
+	Products() map[string]interface{}
+	HasProduct(string) bool
+	Product(string) interface{}
+	SetProduct(string, interface{})
 }
 
 func HumanDescriptionOfDeployment(deployment Deployment) string {

--- a/context/deployment.go
+++ b/context/deployment.go
@@ -15,6 +15,7 @@ type Deployment struct {
 	ref         string
 	sha1        string
 	flags       map[string]interface{}
+	products    map[string]interface{}
 
 	store common.Store
 
@@ -110,6 +111,23 @@ func (deployment *Deployment) Flag(key string) interface{} {
 
 func (deployment *Deployment) SetFlag(key string, value interface{}) {
 	deployment.flags[key] = value
+}
+
+func (deployment *Deployment) Products() map[string]interface{} {
+	return deployment.products
+}
+
+func (deployment *Deployment) HasProduct(key string) bool {
+	_, present := deployment.products[key]
+	return present
+}
+
+func (deployment *Deployment) Product(key string) interface{} {
+	return deployment.products[key]
+}
+
+func (deployment *Deployment) SetProduct(key string, value interface{}) {
+	deployment.products[key] = value
 }
 
 // Looks for the "force" boolean in the `flags`.

--- a/heroku/build.go
+++ b/heroku/build.go
@@ -6,10 +6,19 @@ import (
 	"net/http"
 )
 
+type App struct {
+	Id string `json:"id"`
+}
+
 type Build struct {
 	Id         string      `json:"id"`
+	App        *App        `json:"app"`
 	SourceBlob *SourceBlob `json:"source_blob"`
 	Status     string      `json:"status"`
+}
+
+func (build *Build) DashboardUrl() string {
+	return fmt.Sprintf("https://dashboard.heroku.com/apps/%v/activity/builds/%v", build.App.Id, build.Id)
 }
 
 type SourceBlob struct {

--- a/phases/heroku.go
+++ b/phases/heroku.go
@@ -10,6 +10,7 @@ import (
 )
 
 const TOKEN_FLAG string = "heroku.token"
+const DASHBOARD_URL_PRODUCT string = "heroku.dashboard_url"
 
 // Creates a build via the Heroku API with the deployment's ref/SHA1. The
 // build will use a generated tarball of the repository from GitHub (see its
@@ -79,6 +80,8 @@ func (hbp *HerokuBuildPhase) Execute(deployment common.Deployment, data interfac
 	if err != nil {
 		return err
 	}
+
+	deployment.SetProduct(DASHBOARD_URL_PRODUCT, build.DashboardUrl())
 
 	if build.Status == "failed" {
 		if hbp.OnFailed != nil {


### PR DESCRIPTION
- Adds the concept of a product to a deployment: phases can produce products which can then be used by other phases or custom user code.
- Makes the `HerokuBuildPhase` set the Heroku dashboard URL as a product on the deployment. This enables later notifier phases to pass this URL on to the user. (eg. To allow linking to build output in deploy notifications.)